### PR TITLE
Fix import: num_bigint library is accessible from num as num::bigint.

### DIFF
--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -42,7 +42,7 @@ impl<P: PrimeFieldParams> Field for Fp<P> {
         }
     }
     fn random<R: Rng>(rng: &mut R) -> Self {
-        use num::num_bigint::RandBigInt;
+        use num::bigint::RandBigInt;
         use num::Zero;
 
         Fp {


### PR DESCRIPTION
Don't know the num crate well, but I need to change the name of the use import for the crate to compile.