### PR TITLE
Testing Boneh Franklin IBE on BN curve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 num = "0.1.32"
 rand = "0.3.14"
+
+[dev-dependencies]
+sodiumoxide = "*"

--- a/examples/agg_sigs.rs
+++ b/examples/agg_sigs.rs
@@ -1,0 +1,66 @@
+
+extern crate rand;
+extern crate bn;
+
+use bn::{Field, Scalar, G1, G2, Gt, Fq12, pairing};
+mod sighash;
+use std::collections::HashMap;
+
+
+fn verify_aggregate_sig(agg_sig: &G1, msg_key_pairs: &[(&str, &G2)]) -> bool {
+    let mut unique = HashMap::new();
+    let mut agg_verifier = Gt::new(Fq12::one());
+    for &(msg, ref pub_key) in msg_key_pairs {
+        match unique.get(msg) {
+            Some(&true) => return false, //fail on duplicate messages
+            _ => {} // do nothing
+        }
+        unique.insert(msg, true);
+        let msg_e = G1::random(&mut sighash::SignatureHash::from(msg));
+        agg_verifier = agg_verifier * pairing(&msg_e, &pub_key);
+    }
+    if pairing(agg_sig, &G2::one()) != agg_verifier {
+        return false;
+    }
+    return true;
+}
+
+fn main() {
+    let rng = &mut rand::thread_rng();
+
+    const MSG1: &'static str = "Hello!";
+    const MSG2: &'static str = "Hello!2";
+
+    // Generate Keys
+    let alice_sk = Scalar::random(rng);
+    let bob_sk = Scalar::random(rng);
+
+    // Generate Public Keys
+    let alice_pk = G2::one() * &alice_sk;
+    let bob_pk = G2::one() * &bob_sk;
+    // Generate Signatures
+    let msgm1 = G1::random(&mut sighash::SignatureHash::from(MSG1));
+    let sigm1_a = &msgm1 * &alice_sk;
+
+    let msgm2 = G1::random(&mut sighash::SignatureHash::from(MSG2));
+    let sigm2_b = &msgm2 * &bob_sk;
+
+    // Verify single signatures
+    assert_eq!(pairing(&sigm1_a, &G2::one()), pairing(&msgm1, &alice_pk));
+    assert_eq!(pairing(&sigm2_b, &G2::one()), pairing(&msgm2, &bob_pk));
+
+    // Generate Aggregate Signature
+    let sig_m1m2 = &sigm1_a + &sigm2_b;
+
+    // Verify the Aggregate Signature
+    assert!(verify_aggregate_sig(&sig_m1m2, &[(MSG1, &alice_pk), (MSG2, &bob_pk)]));
+
+    //Test duplicate messages
+    //Generate bob's sig of MSG
+    let sigm1_b = &msgm1 * &bob_sk;
+
+    //Generate duplicate aggregate signature
+    let sig_m1_dup = &sigm1_a + &sigm1_b;
+    assert!(!verify_aggregate_sig(&sig_m1_dup, &[(MSG1, &alice_pk), (MSG1, &bob_pk)]));
+
+}

--- a/examples/bls_sigs.rs
+++ b/examples/bls_sigs.rs
@@ -1,0 +1,22 @@
+    extern crate rand;
+    extern crate bn;
+
+    use bn::{Field, Scalar, G1, G2, pairing};
+    mod sighash;
+
+    fn main() {
+        let rng = &mut rand::thread_rng();
+
+        // Generate Keys
+        let alice_sk = Scalar::random(rng);
+
+        // Generate Public Keys
+        let alice_pk = G2::one() * &alice_sk;
+        // Generate Signature
+        let msgm1 = G1::random(&mut sighash::SignatureHash::from("Hello!"));
+        let sigm1_a = &msgm1 * &alice_sk;
+
+        // Verify single signature
+        assert_eq!(pairing(&sigm1_a, &G2::one()), pairing(&msgm1, &alice_pk));
+
+    }

--- a/examples/ibe.rs
+++ b/examples/ibe.rs
@@ -1,0 +1,61 @@
+extern crate bn;
+extern crate rand;
+extern crate sodiumoxide;
+
+mod sighash;
+
+use bn::*;
+use sodiumoxide::crypto::stream::chacha20;
+use sodiumoxide::crypto::hash::sha256;
+use std::str;
+
+fn main() {
+  ibe();
+}
+
+fn ibe() {
+    let rng       = &mut rand::thread_rng();
+    let master_sk = Scalar::random(rng);
+    // do we need another generator than G1::one() here?
+    // we use G1 since Ppub is used in the first arg of pairing
+    let master_pk = G1::one() * &master_sk;
+
+    let id = b"test";
+
+    let derived = G2::random(&mut sighash::SignatureHash::from(&id[..]));
+    println!("derived: {:?}", derived);
+
+    let id_sk = &derived * &master_sk;
+
+    //encrypting with BasicIdent
+    let r = Scalar::random(rng);
+    let g_id = pairing(&master_pk, &derived) ^ &r;
+    println!("g_id: {:?}", g_id);
+    let badly_serialized = format!("{:?}", g_id);
+    let hash = sha256::hash(badly_serialized.as_bytes());
+
+    println!("hash: {:?}", hash);
+    let sym_key = chacha20::Key::from_slice(&hash[..32]).unwrap();
+    let nonce   = chacha20::gen_nonce();
+
+    let plaintext  = "We propose a fully functional identity-based encryption scheme (IBE). The scheme has chosen ciphertext security in the random oracle model assuming a variant of the computational Diffie-Hellman problem";
+    let ciphertext = chacha20::stream_xor(plaintext.as_bytes(), &nonce, &sym_key);
+
+    // do we need another generator than G1::one() here?
+    let result = (G1::one() * &r, ciphertext);
+    println!("ciphertext: {:?}", result);
+
+    //decrypting
+    let decrypting_seed = pairing(&result.0, &id_sk);
+    let badly_serialized_again = format!("{:?}", decrypting_seed);
+    println!("seed: {:?}", decrypting_seed);
+    assert_eq!(g_id, decrypting_seed);
+    let hash2 = sha256::hash(badly_serialized_again.as_bytes());
+    println!("hash2: {:?}", hash2);
+    let sym_key_2 = chacha20::Key::from_slice(&hash2[..32]).unwrap();
+    let decrypted = chacha20::stream_xor(&result.1, &nonce, &sym_key_2);
+    println!("decrypted: \"{}\"", str::from_utf8(&decrypted).unwrap());
+    assert_eq!(plaintext.as_bytes(), &decrypted[..]);
+
+}
+

--- a/examples/sighash.rs
+++ b/examples/sighash.rs
@@ -1,0 +1,31 @@
+extern crate rand;
+extern crate sodiumoxide;
+
+pub struct SignatureHash(rand::ChaChaRng);
+
+impl rand::Rng for SignatureHash {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+}
+
+impl<'a> From<&'a str> for SignatureHash {
+    fn from(v: &str) -> SignatureHash {
+        SignatureHash::from(v.as_bytes())
+    }
+}
+
+impl<'a> From<&'a [u8]> for SignatureHash {
+    fn from(v: &[u8]) -> SignatureHash {
+        use rand::SeedableRng;
+        use std::slice;
+        use std::mem;
+
+        let hash = sodiumoxide::crypto::hash::sha256::hash(v);
+        assert_eq!(hash.0.len(), 32);
+
+        SignatureHash(rand::ChaChaRng::from_seed(unsafe {
+            slice::from_raw_parts(mem::transmute::<&u8, &u32>(&hash.0[0]), 8)
+        }))
+    }
+}

--- a/examples/sighash.rs
+++ b/examples/sighash.rs
@@ -29,3 +29,6 @@ impl<'a> From<&'a [u8]> for SignatureHash {
         }))
     }
 }
+
+fn main() {
+}

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -42,7 +42,7 @@ impl<P: PrimeFieldParams> Field for Fp<P> {
         }
     }
     fn random<R: Rng>(rng: &mut R) -> Self {
-        use num::num_bigint::RandBigInt;
+        use num::bigint::RandBigInt;
         use num::Zero;
 
         Fp {


### PR DESCRIPTION
This PR implements the [Boneh Franklin "BasicIdent" IBE scheme](https://crypto.stanford.edu/~dabo/papers/bfibe.pdf) with BN curves. I'll update the PR with the `FullIdent` scheme once I write it.

From what I've read, the original scheme works on bilinear pairings, but with `G1 x G2 -> Gt`, it only requires that CDH holds in G1 and G2, and DDH holds in Gt, so it should work on BN curves (could anyone confirm this?).

This PR uses the two previous ones, the first to fix compilation, the second to reuse the sighash module. I'll rebase when those are merged.

What I currently need to move this forward, is a way to serialize a point in compressed form, to generate a hash from it. The way I do it for this test is very ugly: using `format!` and the `Debug` implementation for `g_id`to generate a string, and hashing it with sha256.

A way to serialize and deserialize arbitrary points from G1, G2 and Gt would be useful as well, to transport ciphertexts or signatures.

The hash derived from the shared `g_id` point is used to generate a Chacha20 key instead of XOR-ing it directly with the plaintext. I think it is ok, assuming that Chacha20 is a PRF, but I have not verified it yet. It keeps the malleability from the original scheme, but it would not be hard to derive more data, to do a Chacha20+Poly1305 authenticated encryption (or any other algorithm combination).