### PR TITLE
Add "normalize" method to Group and improve performance of serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bn"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Pairing cryptography with the Barreto-Naehrig curve"
 keywords = ["pairing","crypto","cryptography"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the `bn` crate to your dependencies in `Cargo.toml`...
 
 ```toml
 [dependencies]
-bn = "0.4.0"
+bn = "0.4.1"
 ```
 
 ...and add an `extern crate` declaration to your crate root:

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -112,6 +112,11 @@ impl<P: GroupParams> G<P> {
     pub fn to_affine(&self) -> Option<AffineG<P>> {
         if self.z.is_zero() {
             None
+        } else if self.z == P::Base::one() {
+            Some(AffineG {
+                x: self.x,
+                y: self.y
+            })
         } else {
             let zinv = self.z.inverse().unwrap();
             let zinv_squared = zinv.squared();

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -130,7 +130,7 @@ impl<P: GroupParams> G<P> {
 }
 
 impl<P: GroupParams> AffineG<P> {
-    fn to_jacobian(&self) -> G<P> {
+    pub fn to_jacobian(&self) -> G<P> {
         G {
             x: self.x,
             y: self.y,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub trait Group:
     fn one() -> Self;
     fn random<R: Rng>(rng: &mut R) -> Self;
     fn is_zero(&self) -> bool;
+    fn normalize(&mut self);
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, RustcDecodable, RustcEncodable)]
@@ -84,6 +85,14 @@ impl Group for G1 {
     fn one() -> Self { G1(groups::G1::one()) }
     fn random<R: Rng>(rng: &mut R) -> Self { G1(groups::G1::random(rng)) }
     fn is_zero(&self) -> bool { self.0.is_zero() }
+    fn normalize(&mut self) {
+        let new = match self.0.to_affine() {
+            Some(a) => a,
+            None => return
+        };
+
+        self.0 = new.to_jacobian();
+    }
 }
 
 impl Add<G1> for G1 {
@@ -119,6 +128,14 @@ impl Group for G2 {
     fn one() -> Self { G2(groups::G2::one()) }
     fn random<R: Rng>(rng: &mut R) -> Self { G2(groups::G2::random(rng)) }
     fn is_zero(&self) -> bool { self.0.is_zero() }
+    fn normalize(&mut self) {
+        let new = match self.0.to_affine() {
+            Some(a) => a,
+            None => return
+        };
+
+        self.0 = new.to_jacobian();
+    }
 }
 
 impl Add<G2> for G2 {


### PR DESCRIPTION
This adds a new `normalize` method to `Group` that can be used to speed up serialization in parallel. The jacobian-to-affine conversion will handle the trivial case of z=1, speeding up serialization significantly in some cases. In the future, I would rather elevate this stuff to the type system, but this works for now.

Also, cleaned up the benchmarks.

```
test fq12_exponentiation         ... bench:   5,969,704 ns/iter (+/- 410,626)
test fq12_scalar_multiplication  ... bench:      19,286 ns/iter (+/- 756)
test fr_addition                 ... bench:          22 ns/iter (+/- 5)
test fr_inverses                 ... bench:      10,260 ns/iter (+/- 206)
test fr_multiplication           ... bench:         146 ns/iter (+/- 47)
test fr_subtraction              ... bench:          22 ns/iter (+/- 6)
test g1_addition                 ... bench:       2,597 ns/iter (+/- 200)
test g1_deserialization          ... bench:       1,229 ns/iter (+/- 118)
test g1_scalar_multiplication    ... bench:     633,965 ns/iter (+/- 12,880)
test g1_serialization            ... bench:      11,888 ns/iter (+/- 261)
test g1_serialization_normalized ... bench:         687 ns/iter (+/- 169)
test g1_subtraction              ... bench:       2,606 ns/iter (+/- 152)
test g2_addition                 ... bench:      11,340 ns/iter (+/- 475)
test g2_deserialization          ... bench:       9,407 ns/iter (+/- 273)
test g2_scalar_multiplication    ... bench:   2,728,459 ns/iter (+/- 336,310)
test g2_serialization            ... bench:      15,467 ns/iter (+/- 257)
test g2_serialization_normalized ... bench:       1,353 ns/iter (+/- 146)
test g2_subtraction              ... bench:      11,382 ns/iter (+/- 238)
test perform_pairing             ... bench:   6,992,153 ns/iter (+/- 788,769)
```