### PR TITLE
Don't negate y if point at infinity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bn"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Pairing cryptography with the Barreto-Naehrig curve"
 keywords = ["pairing","crypto","cryptography"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the `bn` crate to your dependencies in `Cargo.toml`...
 
 ```toml
 [dependencies]
-bn = "0.4.2"
+bn = "0.4.3"
 ```
 
 ...and add an `extern crate` declaration to your crate root:

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -821,3 +821,12 @@ fn test_binlinearity() {
         assert_eq!((a.pow(t)) * a, Fq12::one());
     }
 }
+
+#[test]
+fn test_y_at_point_at_infinity() {
+    assert!(G1::zero().y == Fq::one());
+    assert!((-G1::zero()).y == Fq::one());
+
+    assert!(G2::zero().y == Fq2::one());
+    assert!((-G2::zero()).y == Fq2::one());
+}


### PR DESCRIPTION
The y coordinate shouldn't be negated if it's zero. Since z = 0, this doesn't break any library invariants.

I pushed 4e2096bedd67d77370985b5ee92f4ab241c25430 to `master` on accident, so please review that as well. [Edit by @daira: link to commit.]

See also https://github.com/scipr-lab/libsnark/issues/60.

This also bumps the crate version.